### PR TITLE
issue27 fix; see https://github.com/aiten/grails-oauth-scribe/issues/27

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.1.2
+app.grails.version=2.2.4

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -15,7 +15,8 @@ grails.project.dependency.resolution = {
 
     dependencies {
 
-        runtime 'org.scribe:scribe:1.3.2'
+        runtime 'org.scribe:scribe:1.3.5'
+        compile 'org.spockframework:spock-core:0.7-groovy-2.0'
 
         test    'org.gmock:gmock:0.8.2',
                 'org.objenesis:objenesis:1.2'
@@ -24,7 +25,7 @@ grails.project.dependency.resolution = {
 
     plugins {
 
-        test ':spock:0.6', {
+        compile ':spock:0.7', {
             export = false
         }
 

--- a/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
+++ b/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
@@ -17,7 +17,10 @@ class OauthResourceService {
     Response accessResource(OAuthService service, Token accessToken, ResourceAccessor ra) {
 
         OAuthRequest req = buildOauthRequest(ra.verb, ra.url, ra.connectTimeout, ra.receiveTimeout)
-        req.addPayload(ra.payload)
+        
+        if (ra.payload) {
+          req.addPayload(ra.payload)
+        } 
         ra.headers.each { String name, String value ->
             req.addHeader(name, value)
         }

--- a/test/unit/uk/co/desirableobjects/oauth/scribe/OauthResourceServiceSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/oauth/scribe/OauthResourceServiceSpec.groovy
@@ -44,5 +44,36 @@ class OauthResourceServiceSpec extends Specification {
                 0 * _
 
         }
+        def 'null payload should be gracefully handled to avoid NPE'() {
+          
+            given:
+                OAuthService parent = Mock(OAuthService)
 
+            when:
+                ResourceAccessor resourceAccessor = new ResourceAccessor()
+                resourceAccessor.with {
+                    connectTimeout = 5000
+                    receiveTimeout = 5000
+                    verb = Verb.GET
+                    url = 'http://example.net/res'
+                    //payload = null
+                    bodyParameters = [x: 'y']
+                    addHeader 'Accept', 'application/pdf'
+                }
+                assert resourceAccessor.payload == null
+                 service.accessResource(parent, new Token('token', 'secret'), resourceAccessor)
+
+            then:
+                1 * parent.signRequest(new Token('token', 'secret'), { OAuthRequest req ->
+                    req.verb == Verb.GET
+                    req.headers == ['Content-Length': '4', 'Accept': 'application/pdf']
+                    req.url == 'http://example.net/res'
+                    req.bodyContents == 'Test'
+                    req.bodyParams.size() == 1
+                    req.bodyParams.contains(new Parameter('x', 'y'))
+                } as OAuthRequest)
+                0 * _
+
+        }
+          
 }


### PR DESCRIPTION
I created a fork here: https://github.com/bdgarret/grails-oauth-scribe with a branch called issue27

I've added a test to OauthResourceServiceSpec that will fail in order to reproduce the issue (without the fix I added).  
| Failure:  null payload should be gracefully handled to avoid NPE(uk.co.desirableobjects.oauth.scribe.OauthResourceServiceSpec)
|  java.lang.NullPointerException
    at org.scribe.model.Request.addPayload(Request.java:194)
    at uk.co.desirableobjects.oauth.scribe.OauthResourceService.accessResource(OauthResourceService.groovy:25)
    at uk.co.desirableobjects.oauth.scribe.OauthResourceServiceSpec.null payload should be gracefully handled to avoid NPE(OauthResourceServiceSpec.groovy:64)
| Completed 48 spock tests, 1 failed in 9974ms

But with the fix I created in OauthResourceService then the test above succeeds.
| Completed 48 spock tests, 0 failed in 9453ms

The two important files are: OauthResourceServiceSpec and OauthResourceService.  BuildConfig.groovy has the upgrade to scribe 1.3.5 but it also has a couple other things because I am running a later version of groovy.  Feel free to pick and choose what to pull.
