### PR TITLE
Added ability to use query string parameters in requests using dynamic m...

### DIFF
--- a/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
+++ b/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
@@ -27,6 +27,9 @@ class OauthResourceService {
         ra.bodyParameters?.each {String k, String v->
             req.addBodyParameter(k, v)
         }
+	    ra.querystringParams?.each {String name, String value ->
+		    req.addQuerystringParameter(name, value)
+	    }
         return signAndSend(service, accessToken, req)
 
     }

--- a/src/groovy/uk/co/desirableobjects/oauth/scribe/resource/ResourceAccessor.groovy
+++ b/src/groovy/uk/co/desirableobjects/oauth/scribe/resource/ResourceAccessor.groovy
@@ -14,6 +14,7 @@ class ResourceAccessor {
     byte[] payload
     Map<String, String> headers = [:]
     Map<String, String> bodyParameters = [:]
+	Map<String, String> querystringParams = [:]
 
     void setPayload(byte[] data) {
         headers.put('Content-Length', data.length as String)

--- a/test/unit/uk/co/desirableobjects/oauth/scribe/OauthResourceServiceSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/oauth/scribe/OauthResourceServiceSpec.groovy
@@ -75,5 +75,40 @@ class OauthResourceServiceSpec extends Specification {
                 0 * _
 
         }
-          
+
+		def 'querystring parameters should be correctly added to a request when available'() {
+
+			given:
+				OAuthService theParent = Mock(OAuthService)
+				Token aToken = new Token('token', 'secret')
+
+			when: "the resource accessor has querystring parameters"
+				def resourceAccessor = new ResourceAccessor()
+				resourceAccessor.with {
+					verb                = Verb.GET
+					url                 = 'http://example.net/res'
+					querystringParams   = ["value1": "firstValue", "value2": "secondValue"]
+				}
+				service.accessResource(theParent, aToken, resourceAccessor)
+
+			then: "the parent signs a request with the correct querystring params"
+				1 * theParent.signRequest(_ as Token, { OAuthRequest req ->
+					req.queryStringParams.asFormUrlEncodedString() == "value1=firstValue&value2=secondValue"
+				} as OAuthRequest)
+
+			when: "the resource accessor has no querystring parameters"
+				resourceAccessor = new ResourceAccessor()
+				resourceAccessor.with {
+					verb = Verb.GET
+					url = 'http://example.net/res'
+				}
+				service.accessResource(theParent, aToken, resourceAccessor)
+
+			then: "the parent signs a request without any querystring params"
+				1 * theParent.signRequest(_ as Token, { OAuthRequest req ->
+					req.queryStringParams.size() == 0
+				} as OAuthRequest)
+
+		}
+
 }

--- a/test/unit/uk/co/desirableobjects/oauth/scribe/OauthServiceSpec.groovy
+++ b/test/unit/uk/co/desirableobjects/oauth/scribe/OauthServiceSpec.groovy
@@ -361,6 +361,38 @@ class OauthServiceSpec extends Specification {
 
     }
 
+	def "service correctly handles ResourceWithQuerystringParameters methods"() {
+
+		given: "our service"
+			OauthService service = new OauthService()
+			OauthResourceService oauthResourceService = Mock(OauthResourceService)
+			service.oauthResourceService = oauthResourceService
+		and: "a mock provider"
+			OauthProvider aProvider = Mock(OauthProvider)
+			OAuthService theProviderService = Mock(OAuthService)
+			aProvider.getService() >> theProviderService
+			service.services = [twitter: aProvider]
+		and: "the input parameters"
+			def theToken = new Token("a", "b")
+			def theUrl = "http://someapi.net/api"
+			def theQuerystringParams = [param1:"value1", param2:"value2"]
+			def theExtraHeaders = [header1:"valueA", header2:"valueB"]
+
+		when: "using the dynamic method"
+			service.getTwitterResourceWithQuerystringParams(theToken, theUrl, theQuerystringParams, theExtraHeaders)
+
+		then: "the dynamic method is correctly identified"
+			notThrown MissingMethodException
+		and: "the service delegates correctly"
+			1 * oauthResourceService.accessResource(theProviderService, theToken, { resourceAccessor ->
+				resourceAccessor.verb               == Verb.POST
+				resourceAccessor.url                == theUrl
+				resourceAccessor.headers            == theExtraHeaders
+				resourceAccessor.querystringParams  == theQuerystringParams
+			} as ResourceAccessor)
+
+	}
+
     // TODO: What if a dynamic provider requestToken, accessToken etc provider name is not known?
 
     class InvalidProviderApi {


### PR DESCRIPTION
I've added a dynamic method to the OauthService to allow the _org.scribe.model.Request.querystringParameters_ property to be used. An example call to use the changes is: 

``` groovy
def querystringParams = [query: "SELECT Id, DisplayName FROM Customer"]
def extraHeaders = [Accept:"application/json"]

Response res = oauthService.getIntuitResourceWithQuerystringParams(theToken, url, querystringParams, extraHeaders)
```

My reason for the change follows failure to integrate my app with Quickbooks Online using the existing methods. Using _querystringParams_ has been the only method that has worked (so far anyway).

My fork is here: https://github.com/enrobsop/grails-oauth-scribe 

I've added tests which all seem to pass:

``` bash
Paul-Osborne--Mac:~/workspace/grails-oauth-scribe$ grailsw test-app unit:
| Completed 64 spock tests, 0 failed in 6101ms
| Tests PASSED - view reports in /Users/paulosborne/workspace/grails-oauth-scribe/target/test-reports
Paul-Osborne--Mac:~/workspace/grails-oauth-scribe$ 
```

Please let me know if there's anything you want me to change.

Thanks,

Paul
