### PR TITLE
log exception message from remote server for failed getAccessToken request

### DIFF
--- a/grails-app/controllers/uk/co/desirableobjects/oauth/scribe/OauthController.groovy
+++ b/grails-app/controllers/uk/co/desirableobjects/oauth/scribe/OauthController.groovy
@@ -1,5 +1,6 @@
 package uk.co.desirableobjects.oauth.scribe
 
+import org.scribe.exceptions.OAuthException
 import org.scribe.model.Token
 import org.scribe.model.Verifier
 import grails.web.servlet.mvc.GrailsParameterMap
@@ -35,8 +36,8 @@ class OauthController {
 
         try {
             accessToken = oauthService.getAccessToken(providerName, requestToken, verifier)
-        } catch (OAuthException) {
-            log.error("Cannot authenticate with oauth")
+        } catch(OAuthException ex){
+            log.error("Cannot authenticate with oauth: ${ex.toString()}")
             return redirect(uri: provider.failureUri)
         }
 


### PR DESCRIPTION
With this change, we get error messages upon failure of getAccessToken(...) like:

Cannot authenticate with oauth: org.scribe.exceptions.OAuthException: Cannot extract an acces token. Response was: {
  "error" : "invalid_request",
  "error_description" : "Required parameter is missing: grant_type"
}

This information is essential when troubleshooting during initial setup.