### PR TITLE
Scribe Java 4.0.0 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version "3.0.1"
+version "4.0.0"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'

--- a/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
+++ b/grails-app/services/uk/co/desirableobjects/oauth/scribe/OauthResourceService.groovy
@@ -2,11 +2,11 @@ package uk.co.desirableobjects.oauth.scribe
 
 import java.util.concurrent.TimeUnit
 
-import org.scribe.model.OAuthRequest
-import org.scribe.model.Response
-import org.scribe.model.Token
-import org.scribe.model.Verb
-import org.scribe.oauth.OAuthService
+import com.github.scribejava.core.model.OAuthRequest
+import com.github.scribejava.core.model.Response
+import com.github.scribejava.core.model.Token
+import com.github.scribejava.core.model.Verb
+import com.github.scribejava.core.oauth.OAuthService
 
 import uk.co.desirableobjects.oauth.scribe.resource.ResourceAccessor
 
@@ -16,11 +16,11 @@ class OauthResourceService {
 
     Response accessResource(OAuthService service, Token accessToken, ResourceAccessor ra) {
 
-        OAuthRequest req = buildOauthRequest(ra.verb, ra.url, ra.connectTimeout, ra.receiveTimeout)
-        
+        OAuthRequest req = buildOauthRequest(ra.verb, ra.url)
+
         if (ra.payload) {
-          req.addPayload(ra.payload)
-        } 
+          req.setPayload(ra.payload)
+        }
         ra.headers.each { String name, String value ->
             req.addHeader(name, value)
         }
@@ -34,19 +34,16 @@ class OauthResourceService {
 
     }
 
-    private OAuthRequest buildOauthRequest(Verb verb, String url, int connectTimeout, int receiveTimeout) {
+    private OAuthRequest buildOauthRequest(Verb verb, String url) {
 
-        OAuthRequest req = new OAuthRequest(verb, url)
-        req.setConnectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
-        req.setReadTimeout(receiveTimeout, TimeUnit.MILLISECONDS)
-        return req
+        return new OAuthRequest(verb, url)
 
     }
 
     private Response signAndSend(OAuthService service, Token accessToken, OAuthRequest req) {
 
         service.signRequest(accessToken, req)
-        return req.send()
+        return service.execute(req)
 
     }
 }

--- a/grails-app/taglib/uk/co/desirableobjects/oauth/scribe/OauthTagLib.groovy
+++ b/grails-app/taglib/uk/co/desirableobjects/oauth/scribe/OauthTagLib.groovy
@@ -1,7 +1,7 @@
 package uk.co.desirableobjects.oauth.scribe
 
 import org.grails.taglib.GrailsTagException
-import org.scribe.model.Token
+import com.github.scribejava.core.model.Token
 
 class OauthTagLib {
 

--- a/src/main/groovy/uk/co/desirableobjects/oauth/scribe/OauthProvider.groovy
+++ b/src/main/groovy/uk/co/desirableobjects/oauth/scribe/OauthProvider.groovy
@@ -1,6 +1,6 @@
 package uk.co.desirableobjects.oauth.scribe
 
-import org.scribe.oauth.OAuthService
+import com.github.scribejava.core.oauth.OAuthService
 
 class OauthProvider {
 

--- a/src/main/groovy/uk/co/desirableobjects/oauth/scribe/resource/ResourceAccessor.groovy
+++ b/src/main/groovy/uk/co/desirableobjects/oauth/scribe/resource/ResourceAccessor.groovy
@@ -1,13 +1,10 @@
 package uk.co.desirableobjects.oauth.scribe.resource
 
 import groovy.transform.EqualsAndHashCode
-import org.scribe.model.Verb
+import com.github.scribejava.core.model.Verb
 
 @EqualsAndHashCode
 class ResourceAccessor {
-
-    int connectTimeout
-    int receiveTimeout
 
     Verb verb
     String url

--- a/src/main/groovy/uk/co/desirableobjects/oauth/scribe/test/Test10aApiImplementation.groovy
+++ b/src/main/groovy/uk/co/desirableobjects/oauth/scribe/test/Test10aApiImplementation.groovy
@@ -1,6 +1,6 @@
 package uk.co.desirableobjects.oauth.scribe.test
 
-import org.scribe.builder.api.DefaultApi10a
+import com.github.scribejava.core.builder.api.DefaultApi10a
 
 class Test10aApiImplementation extends DefaultApi10a {
 
@@ -15,7 +15,7 @@ class Test10aApiImplementation extends DefaultApi10a {
     }
 
     @Override
-    String getAuthorizationUrl(org.scribe.model.Token token) {
+    String getAuthorizationUrl(com.github.scribejava.core.model.OAuth1RequestToken token) {
         return null
     }
 

--- a/src/test/groovy/uk/co/desirableobjects/oauth/scribe/MockOAuth1Service.groovy
+++ b/src/test/groovy/uk/co/desirableobjects/oauth/scribe/MockOAuth1Service.groovy
@@ -1,0 +1,37 @@
+package uk.co.desirableobjects.oauth.scribe
+
+import com.github.scribejava.core.model.OAuth1AccessToken
+import com.github.scribejava.core.model.OAuth1RequestToken
+import com.github.scribejava.core.model.OAuthConfig
+import com.github.scribejava.core.model.OAuthRequest
+import com.github.scribejava.core.model.Token
+import com.github.scribejava.core.oauth.OAuthService
+import java.util.concurrent.ExecutionException
+
+/* This class exists because some methods on OAuth10aService have been made final and can't be mocked by Spock  */
+public class MockOAuth1Service extends OAuthService<OAuth1AccessToken> {
+
+    public MockOAuth1Service() {
+        super(new OAuthConfig('', ''))
+    }
+
+    public MockOAuth1Service(OAuthConfig config) {
+        super(config)
+    }
+
+    public String getVersion() {
+        return '1.0'
+    }
+
+    public void signRequest(OAuth1AccessToken token, OAuthRequest request) { }
+
+    public OAuth1RequestToken getRequestToken() throws IOException, InterruptedException, ExecutionException {
+       return new OAuth1RequestToken('a', 'b', 'c')
+    }
+
+    public OAuth1AccessToken getAccessToken(OAuth1RequestToken requestToken, String oauthVerifier)
+            throws IOException, InterruptedException, ExecutionException {
+        return new OAuth1AccessToken('d', 'e', 'f')
+    }
+
+}

--- a/src/test/groovy/uk/co/desirableobjects/oauth/scribe/OauthServiceSpec.groovy
+++ b/src/test/groovy/uk/co/desirableobjects/oauth/scribe/OauthServiceSpec.groovy
@@ -1,13 +1,15 @@
 package uk.co.desirableobjects.oauth.scribe
 
 import grails.test.mixin.TestFor
-import org.scribe.builder.ServiceBuilder
-import org.scribe.builder.api.Api
-import org.scribe.builder.api.TwitterApi
-import org.scribe.model.OAuthConfig
-import org.scribe.model.Token
-import org.scribe.model.Verb
-import org.scribe.oauth.OAuthService
+import com.github.scribejava.apis.TwitterApi
+import com.github.scribejava.core.builder.ServiceBuilder
+import com.github.scribejava.core.builder.api.BaseApi
+import com.github.scribejava.core.model.OAuthConfig
+import com.github.scribejava.core.model.OAuth2AccessToken
+import com.github.scribejava.core.model.SignatureType
+import com.github.scribejava.core.model.Token
+import com.github.scribejava.core.model.Verb
+import com.github.scribejava.core.oauth.OAuthService
 import spock.lang.Specification
 import spock.lang.Unroll
 import uk.co.desirableobjects.oauth.scribe.exception.InvalidOauthProviderException
@@ -42,11 +44,11 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: "twitter",
                                 secret: "identica" ],
                             facebook: [
-                                api: org.scribe.builder.api.FacebookApi,
+                                api: com.github.scribejava.apis.FacebookApi,
                                 key: "zuckerberg",
                                 secret: "brothers" ] ]]]]
             service.afterPropertiesSet()
@@ -64,11 +66,11 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: "twitter",
                                 secret: "identica" ],
                             facebook: [
-                                api: org.scribe.builder.api.FacebookApi,
+                                api: com.github.scribejava.apis.FacebookApi,
                                 key: "zuckerberg",
                                 secret: "brothers" ] ]]]]
             service.afterPropertiesSet()
@@ -109,7 +111,7 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: "myKey",
                                 secret: "mySecret" ] ],
                         debug: debug ] ]]
@@ -137,7 +139,7 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: "myKey",
                                 secret: "mySecret",
                                 scope: scope ? 'testScope' : null ] ]]]]
@@ -206,11 +208,11 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: key,
                                 secret: secret ],
                             facebook: [
-                                api: org.scribe.builder.api.FacebookApi,
+                                api: com.github.scribejava.apis.FacebookApi,
                                 key: "facebook-key",
                                 secret: "facebook-secret" ] ]]]]
 
@@ -237,11 +239,11 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: 'myKey',
                                 secret: 'mySecret',
                                 callback: 'http://example.com:1234/url',
-                                signatureType: org.scribe.model.SignatureType.QueryString ] ]]]]
+                                signatureType: SignatureType.QueryString ] ]]]]
 
         expect:
             service.afterPropertiesSet() == null
@@ -256,7 +258,7 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: 'myKey',
                                 secret: 'mySecret',
                                 successUri: '/coffee/tea',
@@ -280,7 +282,7 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: 'myKey',
                                 secret: 'mySecret' ]],
                         connectTimeout: 5000,
@@ -294,13 +296,10 @@ class OauthServiceSpec extends Specification {
             service.receiveTimeout == 5000
 
         when:
-            service.getTwitterResource(new Token('myKey', 'mySecret'), 'http://www.example.com')
+            service.getTwitterResource(new OAuth2AccessToken('myKey', 'mySecret'), 'http://www.example.com')
 
         then:
-            1 * service.oauthResourceService.accessResource(_ as OAuthService, _ as Token, { ResourceAccessor ra ->
-                ra.connectTimeout == 5000
-                ra.receiveTimeout == 5000
-            } as ResourceAccessor)
+            1 * service.oauthResourceService.accessResource(_ as OAuthService, _ as Token, _ as ResourceAccessor)
             0 * _
 
     }
@@ -314,7 +313,7 @@ class OauthServiceSpec extends Specification {
                     oauth: [
                         providers: [
                             twitter: [
-                                api: org.scribe.builder.api.TwitterApi,
+                                api: com.github.scribejava.apis.TwitterApi,
                                 key: 'myKey',
                                 secret: 'mySecret',
                                 successUri: '/coffee/tea',
@@ -350,8 +349,8 @@ class OauthServiceSpec extends Specification {
 
         where:
             apiClass                              | apiVersion
-            'org.scribe.builder.api.TwitterApi'   | SupportedOauthVersion.ONE
-            'org.scribe.builder.api.FacebookApi'  | SupportedOauthVersion.TWO
+            'com.github.scribejava.apis.TwitterApi'   | SupportedOauthVersion.ONE
+            'com.github.scribejava.apis.FacebookApi'  | SupportedOauthVersion.TWO
 
     }
 
@@ -367,7 +366,7 @@ class OauthServiceSpec extends Specification {
 			aProvider.getService() >> theProviderService
 			service.services = [twitter: aProvider]
 		and: "the input parameters"
-			def theToken = new Token("a", "b")
+			def theToken = new OAuth2AccessToken("a", "b")
 			def theUrl = "http://someapi.net/api"
 			def theQuerystringParams = [param1:"value1", param2:"value2"]
 			def theExtraHeaders = [header1:"valueA", header2:"valueB"]
@@ -393,7 +392,7 @@ class OauthServiceSpec extends Specification {
 
     }
 
-    class CustomProviderApi implements Api {
+    class CustomProviderApi implements BaseApi {
 
         OAuthService createService(OAuthConfig oAuthConfig) {
             return null

--- a/src/test/groovy/uk/co/desirableobjects/oauth/scribe/OauthTagLibSpec.groovy
+++ b/src/test/groovy/uk/co/desirableobjects/oauth/scribe/OauthTagLibSpec.groovy
@@ -2,7 +2,8 @@ package uk.co.desirableobjects.oauth.scribe
 
 import grails.test.mixin.TestFor
 import org.grails.taglib.GrailsTagException
-import org.scribe.model.Token
+import com.github.scribejava.core.model.OAuth2AccessToken
+import com.github.scribejava.core.model.Token
 import spock.lang.Specification
 
 @TestFor(OauthTagLib)
@@ -41,9 +42,9 @@ class OauthTagLibSpec extends Specification {
             tagLib.oauthService = new OauthService()
             tagLib.oauthService.findSessionKeyForAccessToken('twitter') >> { return 'twitter:oasAccessToken' }
 
-        and: 
+        and:
 
-            tagLib.session['twitter:oasAccessToken'] = new Token('a', 'b', 'c')
+            tagLib.session['twitter:oasAccessToken'] = new OAuth2AccessToken('a', 'b')
 
         when:
 
@@ -62,7 +63,7 @@ class OauthTagLibSpec extends Specification {
             tagLib.oauthService = new OauthService()
             tagLib.oauthService.findSessionKeyForAccessToken('twitter') >> { return 'twitter:oasAccessToken' }
 
-        and: 
+        and:
 
             tagLib.session['twitter:oasAccessToken'] = null
 
@@ -83,9 +84,9 @@ class OauthTagLibSpec extends Specification {
             tagLib.oauthService = new OauthService()
             tagLib.oauthService.findSessionKeyForAccessToken('twitter') >> { return 'twitter:oasAccessToken' }
 
-        and: 
+        and:
 
-            tagLib.session['twitter:oasAccessToken'] = new Token('a', 'b', 'c')
+            tagLib.session['twitter:oasAccessToken'] = new OAuth2AccessToken('a', 'b')
 
         when:
 
@@ -104,7 +105,7 @@ class OauthTagLibSpec extends Specification {
             tagLib.oauthService = new OauthService()
             tagLib.oauthService.findSessionKeyForAccessToken('twitter') >> { return 'twitter:oasAccessToken' }
 
-        and: 
+        and:
 
             tagLib.session['twitter:oasAccessToken'] = null
 


### PR DESCRIPTION
Updated code to work with Scribe Java 4.0.0 and adjusted tests (all pass now).
Updated plugin version to 4.0.0 due to breaking changes:

- All Scribe classes have been moved to new packages. This means most clients will have to change provider configuration. For example, `org.scribe.builder.api.FacebookApi` is now `com.github.scribejava.apis.FacebookApi`.
- Some method signatures in OauthService.groovy have changed to take into account the differences between OAuth 1 and OAuth 2 in the new Scribe Java. Also, some of the dynamic methods now dispatch to one version or another based on the number of arguments received.
- Clients that make use of Scribe Java directly might have to add the API dependency explicitly: `compile 'com.github.scribejava:scribejava-apis:4.0.0'`

The changes were made somewhat blindly, without a deep understanding of OAuth - the minimum to make the tests pass and enable login with Facebook and Google. Some parts of the code are questionable. For example, OAuth2 does not use a RequestToken now, yet the plugin expects to find a RequestToken in the session in both cases and uses `EMPTY_TOKEN` for OAuth 2. Since Token is abstract in the new library, the value of `EMPTY_TOKEN` has been changed to an `OAuth2AccessToken`, which makes no sense.